### PR TITLE
Remove psutil usage in Audio's manager

### DIFF
--- a/redbot/cogs/audio/errors.py
+++ b/redbot/cogs/audio/errors.py
@@ -51,14 +51,6 @@ class NoProcessFound(ManagedLavalinkNodeException):
     """Exception thrown when the managed node process is not found"""
 
 
-class IncorrectProcessFound(ManagedLavalinkNodeException):
-    """Exception thrown when the managed node process is incorrect"""
-
-
-class TooManyProcessFound(ManagedLavalinkNodeException):
-    """Exception thrown when zombie processes are suspected"""
-
-
 class LavalinkDownloadFailed(ManagedLavalinkNodeException, RuntimeError):
     """Downloading the Lavalink jar failed.
 


### PR DESCRIPTION
### Description of the changes

Regarding Cog-Creators/Red-DiscordBot#5903, I feel like we shouldn't need to use `psutil` anymore now that we fixed the deadlock situation. If you disagree, your feedback is welcome.

### Have the changes in this PR been tested?

No
